### PR TITLE
De maatregel "ICTU geeft de voorkeur aan open source tools" (M15) is …

### DIFF
--- a/Content/Bijlagen/Manifest-Maatregelen.md
+++ b/Content/Bijlagen/Manifest-Maatregelen.md
@@ -12,11 +12,11 @@ De $KWALITEITSAANPAK$ helpt opdrachtgevers van maatwerksoftware het belang van b
 We delen wat we goed kunnen door:
 
 * geleerde lessen te verwerken in deze Kwaliteitsaanpak ([$M11$](#m11)), die te delen tussen projecten en te publiceren via [https://www.ictu.nl/kwaliteitsaanpak](https://www.ictu.nl/kwaliteitsaanpak) ([$M12$](#m12));
-* de tools die we ontwikkelen ter ondersteuning van softwareontwikkelprojecten zoveel mogelijk als open source beschikbaar te stellen ([$M15$](#m15)).
+* de tools die we ontwikkelen ter ondersteuning van softwareontwikkelprojecten zoveel mogelijk als open source beschikbaar te stellen ([$M18$](#m18)).
 
 We gebruiken wat anderen beter doen door:
 
-* open source tools te gebruiken ([$M15$](#m15));
+* open source tools te gebruiken ([$M18$](#m18));
 * bewezen tools te kiezen ([$M16$](#m16)) en beschikbaar te stellen aan projecten in een digitale werkomgeving ([$M19$](#m19)) en het gebruik ervan te ondersteunen ([$M18$](#m18));
 * ons werk periodiek op informatiebeveiliging te laten controleren ([$M26$](#m26));
 * door bij de inzet van medewerkers kwaliteit boven andere aspecten, zoals beschikbaarheid, prijs en doorlooptijd, te laten gaan ([$M21$](#m21)).

--- a/Content/Bijlagen/Overzicht-Maatregelen.md
+++ b/Content/Bijlagen/Overzicht-Maatregelen.md
@@ -30,8 +30,6 @@ Hieronder zijn alle maatregeldefinities uit deze Kwaliteitsaanpak opgenomen, op 
 
 #include "Content/Maatregelen/M14/Definitie.md"
 
-#include "Content/Maatregelen/M15/Definitie.md"
-
 #include "Content/Maatregelen/M16/Definitie.md"
 
 #include "Content/Maatregelen/M18/Definitie.md"

--- a/Content/Bijlagen/Wijzigingsgeschiedenis.md
+++ b/Content/Bijlagen/Wijzigingsgeschiedenis.md
@@ -10,6 +10,7 @@
 * Nieuwe maatregel "Het project beschikt over vastgestelde informatie" (M31) toegevoegd die beschrijft welke informatie de opdrachtgever aan een project beschikbaar stelt.
 * Bij maatregel "Het project levert in elke fase vastgestelde informatie over het product op" (M01) met een plaatje de relaties tussen de voorfase producten toegelicht.
 * De maatregel "Het project is gesplitst in een voorfase en een realisatiefase" (M14) hernoemd naar "Het project bereidt samen met opdrachtgever en belanghebbenden de realisatie voor".
+* De maatregel "ICTU geeft de voorkeur aan open source tools" (M15) is verwijderd. De inhoud van M15 is verplaatst naar "ICTU biedt ondersteuning voor verplicht gestelde tools" (M18). Reden is dat de voorkeur voor open source geen apart uitvoerbare maatregel is, maar deel uitmaakt van de ondersteuning van projecten met tools.
 * Bij maatregel "Het project gebruikt tools voor vastgestelde taken" (M16) performancetesttools toegevoegd.
 * Maatregel "ICTU zorgt dat een aantal vastgestelde tools snel beschikbaar is voor een project" (M17) verwijderd omdat projecten deze tools ofwel via de kantoorautomatisering van ICTU kunnen gebruiken of zelf kunnen draaien in de afgeschermde digitale omgeving zoals beschreven bij M19. 
 * Bij maatregel "Het project laat de beveiliging van het ontwikkelde product periodiek beoordelen" (M26) beter toegelicht onder welke voorwaarden de beveiligingstesten alleen door de opdrachtgever kunnen worden uitgevoerd.

--- a/Content/Maatregelen/M15/Definitie.md
+++ b/Content/Maatregelen/M15/Definitie.md
@@ -1,2 +1,0 @@
-@{**$M15$**
-Bij de selectie van tools ter ondersteuning van de projectuitvoering geeft ICTU voorkeur aan open source tools. Tools die ICTU zelf ontwikkelt ter ondersteuning van softwareontwikkelprojecten, worden bij voorkeur als open source beschikbaar gesteld.}@

--- a/Content/Maatregelen/M15/Maatregel.md
+++ b/Content/Maatregelen/M15/Maatregel.md
@@ -1,7 +1,0 @@
-## $M15$
-
-#include "Content/Maatregelen/M15/Definitie.md"
-
-### Rationale
-
-Conform de rationale uit NORA (Nederlandse Overheid Referentiearchitectuur) voor het gebruik van open source tools, zoals beschreven in NORA v3.0 drijfveer “beleid open standaarden” ([http://www.noraonline.nl/wiki/Beleid_open_standaarden](http://www.noraonline.nl/wiki/Beleid_open_standaarden)).

--- a/Content/Maatregelen/M18/Maatregel.md
+++ b/Content/Maatregelen/M18/Maatregel.md
@@ -4,8 +4,12 @@
 
 ICTU zorgt voor ondersteuning van de bij [$M16$](#m16) verplicht gestelde tools. Een team van specialisten met kennis, ervaring en capaciteit is beschikbaar voor ondersteuning aan projecten.
 
+Bij de selectie van tools ter ondersteuning van de projectuitvoering geeft ICTU de voorkeur aan open source tools. Ook tools die ICTU zelf ontwikkelt ter ondersteuning van softwareontwikkelprojecten worden bij voorkeur open source beschikbaar gesteld.
+
 ### Rationale
 
 De keuze om het gebruik van een aantal tools verplicht te stellen ([$M16$](#m16)) volgt uit de belangrijke rol die die tools spelen in de ontwikkelstraat en in het kwaliteitssysteem. Met de verplichting komt ook een verantwoordelijkheid: om projecten in staat te stellen snel en effectief met deze tools te werken, moeten die projecten ondersteund worden.
 
 De verplicht gestelde tools zijn beperkt in aantal, bewezen en gangbaar; veel medewerkers zullen deze tools al kennen.
+
+De voorkeur voor open source tools is conform de rationale uit NORA (Nederlandse Overheid Referentiearchitectuur) voor het gebruik van open source tools, zoals beschreven in NORA v3.0 drijfveer "[Beleid open standaarden](http://www.noraonline.nl/wiki/Beleid_open_standaarden)". De voorkeur voor het open source beschikbaar stellen van eigen ontwikkelde tools is conform de "[Beleidsbrief vrijgeven van de broncode van overheidssoftware](https://www.rijksoverheid.nl/documenten/kamerstukken/2020/04/17/kamerbrief-inzake-vrijgeven-broncode-overheidssoftware)" van de staatssecretaris van Binnenlandse Zaken en Koninkrijksrelaties, 17 april 2020.

--- a/DocumentDefinitions/Kwaliteitsaanpak/ICTU-Kwaliteitsaanpak.md
+++ b/DocumentDefinitions/Kwaliteitsaanpak/ICTU-Kwaliteitsaanpak.md
@@ -60,8 +60,6 @@
 
 #include "Content/Maatregelen/M18/Maatregel.md"
 
-#include "Content/Maatregelen/M15/Maatregel.md"
-
 #include "Content/Maatregelen/M11/Maatregel.md"
 
 #include "Content/Maatregelen/M12/Maatregel.md"

--- a/DocumentDefinitions/Shared/variables.json
+++ b/DocumentDefinitions/Shared/variables.json
@@ -14,7 +14,6 @@
     "M12": "M12: ICTU publiceert nieuwe versies van de Kwaliteitsaanpak en normen periodiek en op een vaste locatie",
     "M13": "M13: Het project gebruikt ISO-25010 voor de specificatie van productkwaliteitseisen",
     "M14": "M14: Het project bereidt samen met opdrachtgever en belanghebbenden de realisatie voor",
-    "M15": "M15: ICTU geeft de voorkeur aan open source tools",
     "M16": "M16: Het project gebruikt tools voor vastgestelde taken",
     "M18": "M18: ICTU biedt ondersteuning voor verplicht gestelde tools",
     "M19": "M19: ICTU biedt projecten een afgeschermde digitale omgeving",


### PR DESCRIPTION
…verwijderd. De inhoud van M15 is verplaatst naar "ICTU biedt ondersteuning voor verplicht gestelde tools" (M18). Reden is dat de voorkeur voor open source geen apart uitvoerbare maatregel is, maar deel uitmaakt van de ondersteuning van projecten met tools. Closes #298."