### PR TITLE
Actueel houden externe software.

### DIFF
--- a/Content/Maatregelen/M16/Definitie.md
+++ b/Content/Maatregelen/M16/Definitie.md
@@ -14,10 +14,11 @@ ICTU stelt het gebruik van tools verplicht voor de volgende taken:
 10. statische controle van de software op aanwezigheid van kwetsbare constructies,
 11. dynamische controle van de software op aanwezigheid van kwetsbare constructies,
 12. controleren van container images op aanwezigheid van bekende kwetsbaarheden,
-13. testen van performance en schaalbaarheid,
-14. testen op toegankelijkheid van de applicatie,
-15. produceren van een "software bill of materials" (SBoM),
-16. opslaan van artifacten,
-17. registratie van incidenten bij gebruik en beheer, en
-18. bij het uitvoeren van operationeel beheer; uitrollen van de software in de productieomgeving.
+13. actueel houden van externe software,
+14. testen van performance en schaalbaarheid,
+15. testen op toegankelijkheid van de applicatie,
+16. produceren van een "software bill of materials" (SBoM),
+17. opslaan van artifacten,
+18. registratie van incidenten bij gebruik en beheer, en
+19. bij het uitvoeren van operationeel beheer; uitrollen van de software in de productieomgeving.
 <!-- end: measure -->

--- a/Content/Maatregelen/M16/Maatregel.md
+++ b/Content/Maatregelen/M16/Maatregel.md
@@ -18,12 +18,13 @@ ICTU adviseert en ondersteunt voor de genoemde taken onderstaande tools. Project
 10. statische controle van de software op aanwezigheid van kwetsbare constructies: SonarQube,
 11. dynamische controle van de software op aanwezigheid van kwetsbare constructies: ZAP (Zed Attack Proxy) by Checkmarx,
 12. controleren van container images op aanwezigheid van bekende kwetsbaarheden: Trivy,
-13. testen van performance en schaalbaarheid: JMeter en Performancetestrunner,
-14. testen op toegankelijkheid van de applicatie: Axe,
-15. produceren van een "software bill of materials" (SBoM): tools die een SBoM in CycloneDX-formaat (zie https://cyclonedx.org) genereren,
-16. opslaan van artifacten: Nexus of Harbor,
-17. registratie van incidenten bij gebruik en beheer: Jira, en
-18. bij het uitvoeren van operationeel beheer; uitrollen van de software in de productieomgeving: Ansible.
+13. actueel houden van externe software: RenovateBot,
+14. testen van performance en schaalbaarheid: JMeter en Performancetestrunner,
+15. testen op toegankelijkheid van de applicatie: Axe,
+16. produceren van een "software bill of materials" (SBoM): tools die een SBoM in CycloneDX-formaat (zie https://cyclonedx.org) genereren,
+17. opslaan van artifacten: Nexus of Harbor,
+18. registratie van incidenten bij gebruik en beheer: Jira, en
+19. bij het uitvoeren van operationeel beheer; uitrollen van de software in de productieomgeving: Ansible.
 
 ### Rationale
 

--- a/Content/Wijzigingsgeschiedenis.md
+++ b/Content/Wijzigingsgeschiedenis.md
@@ -1,3 +1,9 @@
+# Versie 5.0.0, nog niet gereleased
+
+## Kwaliteitsaanpak
+
+* In maatregel M16 "Het project gebruikt tools voor vastgestelde taken" de taak "actueel houden van externe software" toegevoegd.
+
 # Versie 4.1.0, nog niet gereleased
 
 ## Template Niet-Functionele Eisen


### PR DESCRIPTION
In maatregel M16 "Het project gebruikt tools voor vastgestelde taken" de taak "actueel houden van externe software" toegevoegd.

Closes #392.