### PR TITLE
M29 tekstuele aanpassing

### DIFF
--- a/Content/Maatregelen/M29/Maatregel.md
+++ b/Content/Maatregelen/M29/Maatregel.md
@@ -2,7 +2,7 @@
 
 #include "Content/Maatregelen/M29/Definitie.md"
 
-Voordat ICTU een project start en een overeenkomst sluit met de opdrachtgevende organisatie maakt de beoogde ICTU-projectleider afspraken met de afdeling ISD over de door ISD geleverde voorzieningen die het project gaat afnemen en met de afdeling ISE over de medewerkers van de afdeling ISE die het project gaat inzetten.
+De beoogde ICTU-projectleider maakt afspraken met de afdeling ISD over de door ISD geleverde voorzieningen die het project gaat afnemen en met de afdeling ISE over de medewerkers van de afdeling ISE die het project gaat inzetten.
 
 Hierbij bewaken ISD en ISE dat de omvang, de snelheid van opschaling, en de behoefte aan ondersteuning van het project zodanig is dat dit samengaat met ongestoorde dienstverlening aan de lopende projecten.
 

--- a/Content/Wijzigingsgeschiedenis.md
+++ b/Content/Wijzigingsgeschiedenis.md
@@ -1,5 +1,9 @@
 # Work-in-progress
 
+## Kwaliteitsaanpak
+
+* In M29 "ICTU organiseert voor aanvang van een project de interne dienstverlening" beginnen de samenvatting en de eerste alinea van de beschrijving met dezelfde woorden waardoor het in de popup in de self-assessment spreadsheet (die geen opmaak heeft) lijkt alsof er twee keer hetzelfde staat. Formulering aangepast.
+
 ## Template Niet-functionele Eisen
 
 * Spelfout in "Compatibility" opgelost.


### PR DESCRIPTION
In M29 "ICTU organiseert voor aanvang van een project de interne dienstverlening" beginnen de samenvatting en de eerste alinea van de beschrijving met dezelfde woorden waardoor het in de popup in de self-assessment spreadsheet (die geen opmaak heeft) lijkt alsof er twee keer hetzelfde staat. Formulering aangepast.

Fixes #1078.