### PR TITLE
Trivy vervangen door Grype

### DIFF
--- a/Content/Maatregelen/M16/Maatregel.md
+++ b/Content/Maatregelen/M16/Maatregel.md
@@ -16,7 +16,7 @@ ICTU adviseert en ondersteunt voor de hieronder genoemde taken specifieke tools.
 | [submeasure-title]Controleren op aanwezigheid van bekende kwetsbaarheden in externe software[/submeasure-title] | OWASP (Open Web Application Security Project) Dependency-Check en/of Dependency-Track |
 | [submeasure-title]Statische controle van de software op aanwezigheid van kwetsbare constructies[/submeasure-title] | SonarQube |
 | [submeasure-title]Dynamische controle van de software op aanwezigheid van kwetsbare constructies[/submeasure-title] | ZAP (Zed Attack Proxy) by Checkmarx |
-| [submeasure-title]Controleren van container images op aanwezigheid van bekende kwetsbaarheden[/submeasure-title] | Trivy |
+| [submeasure-title]Controleren van container images op aanwezigheid van bekende kwetsbaarheden[/submeasure-title] | Grype |
 | [submeasure-title]Testen van performance en schaalbaarheid[/submeasure-title] | JMeter en Performancetestrunner |
 | [submeasure-title]Testen op toegankelijkheid van de applicatie[/submeasure-title] | Axe |
 | [submeasure-title]Produceren van een "software bill of materials" (SBoM)[/submeasure-title] | Tools die een SBoM in CycloneDX-formaat (zie https://cyclonedx.org) genereren |

--- a/Content/Templates/PvA-Realisatiefase/Template-Inhoud.md
+++ b/Content/Templates/PvA-Realisatiefase/Template-Inhoud.md
@@ -30,7 +30,7 @@ Binnen de scope van de opdracht valt de {ontwikkeling en/of het onderhoud} van {
 
 * Ontwikkel, test- en demo-omgevingen,
 * Engineering tools voor versiebeheer (GitLab of Azure DevOps), bouwen en testen (Azure DevOps, GitLab en/of Jenkins), kwaliteitscontrole (SonarQube), beveiligingscontrole (SonarQube, OWASP Dependency-Check en/of Dependency-Track en ZAP by Checkmarx), toegankelijkheid (Axe), performancetesten (JMeter) en integrale kwaliteitsrapportage (Quality-time),
-* {Als operationeel beheer onderdeel is van de dienstverlening:} Uitrollen in de productieomgeving (Ansible), container registry (Harbor), performance monitoring (APM), security monitoring ({vul aan met concreet product}), controle van kwetsbaarheden in frameworks ({vul aan met concreet product}), controle van images van containers (Trivy), registratie van incidenten bij gebruik en beheer (Topdesk of Jira).
+* {Als operationeel beheer onderdeel is van de dienstverlening:} Uitrollen in de productieomgeving (Ansible), container registry (Harbor), performance monitoring (APM), security monitoring ({vul aan met concreet product}), controle van kwetsbaarheden in frameworks ({vul aan met concreet product}), controle van images van containers (Grype), registratie van incidenten bij gebruik en beheer (Topdesk of Jira).
 * Product en sprint backlog management tools (Jira en/of Azure DevOps),
 * Beveiligings- en performancetesten in de ICTU-testomgevingen. ICTU voert deze tests uit voordat een nieuwe versie van de software wordt opgeleverd. {Beschrijf hier eventuele andere afspraken met de opdrachtgevende organisatie}.
 

--- a/Content/Wijzigingsgeschiedenis.md
+++ b/Content/Wijzigingsgeschiedenis.md
@@ -1,3 +1,13 @@
+# Versie 6.0.0, nog te releasen
+
+## Kwaliteitsaanpak
+
+* In M16 "Het project gebruikt tools voor vastgestelde taken", Trivy vervangen door Grype als geadviseerd tool voor het controleren van container images op aanwezigheid van bekende kwetsbaarheden.
+
+## Template Plan van Aanpak Realisatiefase
+
+* Trivy vervangen door Grype als tool voor het controleren van container images op aanwezigheid van bekende kwetsbaarheden.
+
 # Versie 5.2.0, 14 april 2026
 
 ## Template Kwaliteitsplan
@@ -12,7 +22,7 @@
 
 ## Alle documenten
 
-* Externe verwijzingen en URLs bijgewerkt. 
+* Externe verwijzingen en URLs bijgewerkt.
 * Spelfout in "SSD" opgelost.
 
 # Versie 5.1.0, 6 januari 2026


### PR DESCRIPTION
In M16 "Het project gebruikt tools voor vastgestelde taken" en het PvA Realisatiefase, Trivy vervangen door Grype als geadviseerd tool voor het controleren van container images op aanwezigheid van bekende kwetsbaarheden.

Closes #1145.